### PR TITLE
<#30> 내 소개 페이지 레이아웃 구현

### DIFF
--- a/atom/atom.resume.ts
+++ b/atom/atom.resume.ts
@@ -1,0 +1,71 @@
+import { atom } from 'recoil';
+import { v1 } from 'uuid';
+
+import { EduType, PjType, SharedType } from '@/types/atom.types';
+
+export const eduState = atom<EduType []>({
+  key: `eduState${v1()}`,
+  default: [
+    {
+      id: `부경대학교${v1()}`,
+      type: '대학교',
+      title: '부경대학교',
+      explains: [
+        '2016 - 2022 컴퓨터공학과 4학년 재학 중',
+        '학점 3.65 / 4.5',
+      ],
+    },
+    {
+      id: `네이버${v1()}`,
+      type: '교육',
+      title: '네이버 부스트 캠프 챌린지 6기',
+      explains: [
+        '네이버 부스트 캠프 챌린지 2021/07/19 ~ 2021/08/20 진행',
+        '멤버쉽 과정 불합격',
+      ],
+    },
+    {
+      id: `프로그래머스${v1()}`,
+      type: '교육',
+      title: '프로그래머스 프론트엔드 자바스크립트 온라인 스터디 12기',
+      explains: [
+        '2021/10/13 ~ 2021/11/13 진행',
+        'JavaScript로 React, Vue 같은 프레임워크처럼 개발하는 방법에 대해 학습',
+      ],
+    },
+  ],
+});
+
+export const shareState = atom<SharedType []>({
+  key: `shareState${v1()}`,
+  default: [
+    {
+      id: `블로그${v1()}`,
+      title: '벨로그',
+      type: '블로그',
+      explains: [
+        '알고리즘, CS지식 공부 내용, 회고록 등등을 정리',
+        '프로젝트 스프린트 후기 및 내용 정리',
+      ],
+    },
+  ],
+});
+
+export const pjState = atom<PjType []>({
+  key: `projectState${v1()}`,
+  default: [
+    {
+      id: `준승 포트폴리오${v1()}`,
+      title: '준승 포트폴리오',
+      type: '개인 프로젝트',
+      period: '2022년 8월 22일 ~ 계속 개발 중',
+      explains: [
+        'hi', 'hi', 'hi',
+      ],
+      worries: [
+        'hi', 'hi',
+      ],
+      readme: 'hi',
+    },
+  ],
+});

--- a/components/resume/Eduction.tsx
+++ b/components/resume/Eduction.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import oc from 'open-color';
+
+import { media, sizes } from '@/stylesheets/utils';
+
+const EducationContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  padding-left: 2rem;
+  padding-right: 2rem;
+
+  width: ${sizes.wide};
+
+  @media ${media.wide} {
+    width: 100%;
+  }
+
+  div + div {
+    margin-top: 1.2rem;
+  }
+
+  h3 + div {
+    margin-top: 1.2rem;
+  }
+`;
+
+const EducationTitle = styled.h2`
+  font-size: 5rem;
+
+  &::after {
+    content: '.';
+    color: ${oc.teal[6]}
+  }
+`;
+
+const EducationLine = styled.div`
+  width: 100%;
+  height: 0.5rem;
+
+  margin-top: 2rem;
+  background-image: linear-gradient(90deg, ${oc.teal[6]} 20%, ${oc.cyan[6]} 80%);
+  margin-bottom: 1.5rem;
+`;
+
+const Title = styled.h3`
+  margin-top: 1.5rem;
+  font-size: 2.5rem;
+  font-weight: bold;
+`;
+
+const EducationType = styled.div`
+  font-size: 1.5rem;
+`;
+
+const EducationExplain = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 1.5rem;
+
+  &::before {
+    content: url("data:image/svg+xml,%3Csvg width='18px' height='18px' viewBox='0 0 48 48' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='48' height='48' fill='white' fill-opacity='0.01'/%3E%3Cpath d='M43 11L16.875 37L5 25.1818' stroke='teal' stroke-width='4' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E%0A");    
+    margin-right: 0.5rem;
+    
+  }
+
+  line-height: 1.5rem;
+`;
+
+const Education: React.FC = () => {
+  return (
+    <EducationContainer>
+      <EducationTitle>Education</EducationTitle>
+      <EducationLine />
+
+      <EducationType>대학교</EducationType>
+      <Title>부경대학교</Title>
+      <EducationExplain>2016 - 2022 컴퓨터공학과 4학년 재학 중</EducationExplain>
+      <EducationExplain>학점 3.65 / 4.5</EducationExplain>
+
+      <EducationType>교육</EducationType>
+      <Title>네이버 부스트 캠프 챌린지 6기</Title>
+      <EducationExplain>네이버 부스트 캠프 챌린지 2021/07/19 ~ 2021/08/20 진행</EducationExplain>
+      <EducationExplain>멤버쉽 과정 불합격</EducationExplain>
+
+      <EducationType>교육</EducationType>
+      <Title>프로그래머스 프론트엔드 자바스크립트 온라인 스터디 12기</Title>
+      <EducationExplain>2021/10/13 ~ 2021/11/13 진행</EducationExplain>
+      <EducationExplain>JavaScript로 React, Vue 같은 프레임워크처럼 개발하는 방법에 대해 학습</EducationExplain>
+
+    </EducationContainer>
+  );
+};
+
+export default Education;

--- a/components/resume/Eduction.tsx
+++ b/components/resume/Eduction.tsx
@@ -1,95 +1,59 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import oc from 'open-color';
+import { useRecoilValue } from 'recoil';
+import { eduState } from '@/atom/atom.resume';
+import { EduType } from '@/types/atom.types';
 
-import { media, sizes } from '@/stylesheets/utils';
+import * as ResumeStyle from '@/stylesheets/resume';
+
+import ResumeHeader from '@/components/resume/ResumeHeader';
 
 const EducationContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-
-  padding-left: 2rem;
-  padding-right: 2rem;
-
-  width: ${sizes.wide};
-
-  @media ${media.wide} {
-    width: 100%;
-  }
-
-  div + div {
-    margin-top: 1.2rem;
-  }
-
-  h3 + div {
-    margin-top: 1.2rem;
-  }
+  ${ResumeStyle.Container}
 `;
 
-const EducationTitle = styled.h2`
-  font-size: 5rem;
-
-  &::after {
-    content: '.';
-    color: ${oc.teal[6]}
-  }
-`;
-
-const EducationLine = styled.div`
-  width: 100%;
-  height: 0.5rem;
-
-  margin-top: 2rem;
-  background-image: linear-gradient(90deg, ${oc.teal[6]} 20%, ${oc.cyan[6]} 80%);
-  margin-bottom: 1.5rem;
-`;
-
-const Title = styled.h3`
-  margin-top: 1.5rem;
-  font-size: 2.5rem;
-  font-weight: bold;
+const EducationTitle = styled.h3`
+  ${ResumeStyle.Title}
 `;
 
 const EducationType = styled.div`
-  font-size: 1.5rem;
+  ${ResumeStyle.Type}
 `;
 
 const EducationExplain = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  font-size: 1.5rem;
+  ${ResumeStyle.Explain}
+`;
 
-  &::before {
-    content: url("data:image/svg+xml,%3Csvg width='18px' height='18px' viewBox='0 0 48 48' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='48' height='48' fill='white' fill-opacity='0.01'/%3E%3Cpath d='M43 11L16.875 37L5 25.1818' stroke='teal' stroke-width='4' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E%0A");    
-    margin-right: 0.5rem;
-    
+const EducationContent = styled.ul`
+  li + li {
+    margin-top: 4rem;
   }
-
-  line-height: 1.5rem;
 `;
 
 const Education: React.FC = () => {
+  const edus = useRecoilValue<EduType []>(eduState);
+
   return (
     <EducationContainer>
-      <EducationTitle>Education</EducationTitle>
-      <EducationLine />
-
-      <EducationType>대학교</EducationType>
-      <Title>부경대학교</Title>
-      <EducationExplain>2016 - 2022 컴퓨터공학과 4학년 재학 중</EducationExplain>
-      <EducationExplain>학점 3.65 / 4.5</EducationExplain>
-
-      <EducationType>교육</EducationType>
-      <Title>네이버 부스트 캠프 챌린지 6기</Title>
-      <EducationExplain>네이버 부스트 캠프 챌린지 2021/07/19 ~ 2021/08/20 진행</EducationExplain>
-      <EducationExplain>멤버쉽 과정 불합격</EducationExplain>
-
-      <EducationType>교육</EducationType>
-      <Title>프로그래머스 프론트엔드 자바스크립트 온라인 스터디 12기</Title>
-      <EducationExplain>2021/10/13 ~ 2021/11/13 진행</EducationExplain>
-      <EducationExplain>JavaScript로 React, Vue 같은 프레임워크처럼 개발하는 방법에 대해 학습</EducationExplain>
-
+      <ResumeHeader name="Education" />
+      <EducationContent>
+        {
+          edus.map((edu) => {
+            return (
+              <li key={edu.id}>
+                <EducationType>{edu.type}</EducationType>
+                <EducationTitle>{edu.title}</EducationTitle>
+                {
+                  edu.explains.map((explain) => {
+                    return <EducationExplain key={explain}>{explain}</EducationExplain>;
+                  })
+                }
+              </li>
+            );
+          })
+        }
+      </EducationContent>
     </EducationContainer>
   );
 };

--- a/components/resume/Project.tsx
+++ b/components/resume/Project.tsx
@@ -1,50 +1,80 @@
 import React from 'react';
 import styled from 'styled-components';
-import oc from 'open-color';
 
-import { media, sizes } from '@/stylesheets/utils';
-import { ReactProps } from '@/types/common.types';
+import { useRecoilValue } from 'recoil';
+import { pjState } from '@/atom/atom.resume';
+import { PjType } from '@/types/atom.types';
+
+import * as ResumeStyle from '@/stylesheets/resume';
+
+import ResumeHeader from '@/components/resume/ResumeHeader';
 
 const ProjectContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-
-  padding-left: 2rem;
-  padding-right: 2rem;
-
-  width: ${sizes.wide};
-
-  @media ${media.wide} {
-    width: 100%;
-  }
-
+  ${ResumeStyle.Container}
   margin-top: 5rem;
-
 `;
 
-const ProjectTitle = styled.h2`
-  font-size: 5rem;
+const ProjectTitle = styled.h3`
+  ${ResumeStyle.Title}
+`;
 
-  &::after {
-    content: '.';
-    color: ${oc.teal[6]}
+const ProjectType = styled.div`
+  ${ResumeStyle.Type}
+`;
+
+const ProjectExplain = styled.div`
+  ${ResumeStyle.Explain}
+`;
+
+const ProjectContent = styled.ul`
+  li + li {
+    margin-top: 4rem;
+  }
+
+  h4 + div {
+    margin-top: 1.2rem;
   }
 `;
 
-const ProjectLine = styled.div`
-  width: 100%;
-  height: 0.5rem;
-
-  margin-top: 2rem;
-  background-image: linear-gradient(90deg, ${oc.teal[6]} 20%, ${oc.cyan[6]} 80%);
+const ProjectWorryTitle = styled.h4`
+  ${ResumeStyle.WorryTitle}
 `;
 
-const Project: React.FC<ReactProps> = ({ children }) => {
+const ProjectReadmeTitle = styled.h4`
+  ${ResumeStyle.ReadmeTitle}
+`;
+
+const Project: React.FC = () => {
+  const projects = useRecoilValue<PjType []>(pjState);
+
   return (
     <ProjectContainer>
-      <ProjectTitle>Project</ProjectTitle>
-      <ProjectLine />
-      {children}
+      <ResumeHeader name="Project" />
+      <ProjectContent>
+        {
+        projects.map((project) => {
+          return (
+            <li key={project.id}>
+              <ProjectType>{project.type}</ProjectType>
+              <ProjectTitle>{project.title}</ProjectTitle>
+              {
+                project.explains.map((explain) => {
+                  return <ProjectExplain key={explain}>{explain}</ProjectExplain>;
+                })
+              }
+              <ProjectWorryTitle>프로젝트 구현 시 했던 고민들</ProjectWorryTitle>
+              {
+                project.worries.map((worry) => {
+                  return <ProjectExplain key={worry}>{worry}</ProjectExplain>;
+                })
+              }
+              <ProjectReadmeTitle>리드미</ProjectReadmeTitle>
+              <ProjectExplain>{project.readme}</ProjectExplain>
+            </li>
+          );
+        })
+      }
+      </ProjectContent>
     </ProjectContainer>
   );
 };

--- a/components/resume/Project.tsx
+++ b/components/resume/Project.tsx
@@ -14,9 +14,11 @@ const ProjectContainer = styled.div`
 
   width: ${sizes.wide};
 
-  @media ${media.tablet} {
+  @media ${media.wide} {
     width: 100%;
   }
+
+  margin-top: 5rem;
 
 `;
 

--- a/components/resume/Project.tsx
+++ b/components/resume/Project.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import styled from 'styled-components';
+import oc from 'open-color';
+
+import { media, sizes } from '@/stylesheets/utils';
+import { ReactProps } from '@/types/common.types';
+
+const ProjectContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  padding-left: 2rem;
+  padding-right: 2rem;
+
+  width: ${sizes.wide};
+
+  @media ${media.tablet} {
+    width: 100%;
+  }
+
+`;
+
+const ProjectTitle = styled.h2`
+  font-size: 5rem;
+
+  &::after {
+    content: '.';
+    color: ${oc.teal[6]}
+  }
+`;
+
+const ProjectLine = styled.div`
+  width: 100%;
+  height: 0.5rem;
+
+  margin-top: 2rem;
+  background-image: linear-gradient(90deg, ${oc.teal[6]} 20%, ${oc.cyan[6]} 80%);
+`;
+
+const Project: React.FC<ReactProps> = ({ children }) => {
+  return (
+    <ProjectContainer>
+      <ProjectTitle>Project</ProjectTitle>
+      <ProjectLine />
+      {children}
+    </ProjectContainer>
+  );
+};
+
+export default Project;

--- a/components/resume/ProjectPortfolio.tsx
+++ b/components/resume/ProjectPortfolio.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import styled from 'styled-components';
+import Link from 'next/link';
+
+const ProjectPortfolioContainer = styled.div`
+  margin-top: 3rem;
+
+  div + div {
+    margin-top: 1.2rem;
+  }
+
+  h4 + div {
+    margin-top: 1.2rem;
+  }
+`;
+
+const ProjectType = styled.div`
+  font-size: 1.5rem;
+`;
+
+const Title = styled.h3`
+  margin-top: 1.5rem;
+  font-size: 2.5rem;
+  font-weight: bold;
+`;
+
+const ProjectPeriod = styled.div`
+  margin-top: 1.2rem;
+  font-size: 1rem;
+`;
+
+const ProjectExplain = styled.div`
+  font-size: 1.5rem;
+
+  &::before {
+    content: url("data:image/svg+xml,%3Csvg width='18px' height='18px' viewBox='0 0 48 48' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='48' height='48' fill='white' fill-opacity='0.01'/%3E%3Cpath d='M43 11L16.875 37L5 25.1818' stroke='teal' stroke-width='4' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E%0A");    
+    margin-right: 0.5rem;
+    
+  }
+
+  line-height: 1rem;
+`;
+
+const ProjectWorry = styled.h4`
+  margin-top: 1.5rem;
+  font-size: 1.5rem;
+
+  &::before {
+    content: url("data:image/svg+xml,%3Csvg width='20px' height='20px' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' x='0px' y='0px' viewBox='0 0 53 53' style='enable-background:new 0 0 53 53;' xml:space='preserve'%3E%3Cpath style='fill:%23EFCE4A;' d='M26.5,9c-8.837,0-16,7.164-16,16c0,7.089,4.615,13.091,11,15.192V50h2v3h6v-3h2v-9.808 c6.385-2.101,11-8.103,11-15.192C42.5,16.164,35.337,9,26.5,9z'/%3E%3Cg%3E%3Cpath style='fill:%23EFCE4A;' d='M26.5,0c-0.553,0-1,0.447-1,1v4c0,0.553,0.447,1,1,1s1-0.447,1-1V1C27.5,0.447,27.053,0,26.5,0z'/%3E%3Cpath style='fill:%23EFCE4A;' d='M50.5,24h-4c-0.553,0-1,0.447-1,1s0.447,1,1,1h4c0.553,0,1-0.447,1-1S51.053,24,50.5,24z'/%3E%3Cpath style='fill:%23EFCE4A;' d='M6.5,24h-4c-0.553,0-1,0.447-1,1s0.447,1,1,1h4c0.553,0,1-0.447,1-1S7.053,24,6.5,24z'/%3E%3Cpath style='fill:%23EFCE4A;' d='M42.764,7.322l-2.828,2.828c-0.391,0.391-0.391,1.023,0,1.414c0.195,0.195,0.451,0.293,0.707,0.293 s0.512-0.098,0.707-0.293l2.828-2.828c0.391-0.391,0.391-1.023,0-1.414S43.154,6.932,42.764,7.322z'/%3E%3Cpath style='fill:%23EFCE4A;' d='M11.65,38.436l-2.828,2.828c-0.391,0.391-0.391,1.023,0,1.414c0.195,0.195,0.451,0.293,0.707,0.293 s0.512-0.098,0.707-0.293l2.828-2.828c0.391-0.391,0.391-1.023,0-1.414S12.041,38.045,11.65,38.436z'/%3E%3Cpath style='fill:%23EFCE4A;' d='M41.35,38.436c-0.391-0.391-1.023-0.391-1.414,0s-0.391,1.023,0,1.414l2.828,2.828 c0.195,0.195,0.451,0.293,0.707,0.293s0.512-0.098,0.707-0.293c0.391-0.391,0.391-1.023,0-1.414L41.35,38.436z'/%3E%3Cpath style='fill:%23EFCE4A;' d='M10.236,7.322c-0.391-0.391-1.023-0.391-1.414,0s-0.391,1.023,0,1.414l2.828,2.828 c0.195,0.195,0.451,0.293,0.707,0.293s0.512-0.098,0.707-0.293c0.391-0.391,0.391-1.023,0-1.414L10.236,7.322z'/%3E%3C/g%3E%3Cpath style='fill:%23F7E6A1;' d='M15.5,26c-0.553,0-1-0.447-1-1c0-6.617,5.383-12,12-12c0.553,0,1,0.447,1,1s-0.447,1-1,1 c-5.514,0-10,4.486-10,10C16.5,25.553,16.053,26,15.5,26z'/%3E%3Cpolygon style='fill:%23556080;' points='21.5,43 21.5,50 23.5,50 23.5,53 29.5,53 29.5,50 31.5,50 31.5,43 '/%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3C/svg%3E%0A");
+    margin-right: 0.5rem;
+  }
+
+`;
+
+const ProjectReadme = styled.div`
+  margin-top: 1.2rem;
+  font-size: 1.5rem;
+
+  &::before {
+    content: url("data:image/svg+xml,%3Csvg fill='gray' width='20px' height='20px' viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 5 6 C 3.346 6 2 7.346 2 9 L 2 21 C 2 22.654 3.346 24 5 24 L 11.183594 23.980469 C 12.173594 23.980469 13.133031 24.290844 13.957031 24.839844 L 16 26.201172 L 18.042969 24.839844 C 18.866969 24.290844 19.826406 24 20.816406 24 L 27 24 C 28.654 24 30 22.654 30 21 L 30 9 C 30 7.346 28.654 6 27 6 L 20.816406 6 C 19.430406 6 18.086594 6.4077813 16.933594 7.1757812 L 16 7.7988281 L 15.066406 7.1757812 C 13.912406 6.4067813 12.570594 6 11.183594 6 L 5 6 z M 5 8 L 11.183594 8 C 12.173594 8 13.133031 8.2908438 13.957031 8.8398438 L 16 10.201172 L 18.042969 8.8398438 C 18.866969 8.2908438 19.826406 8 20.816406 8 L 27 8 C 27.552 8 28 8.449 28 9 L 28 21 C 28 21.551 27.552 22 27 22 L 20.816406 22 C 19.430406 22 18.086594 22.407781 16.933594 23.175781 L 16 23.798828 L 15.066406 23.175781 C 13.912406 22.406781 12.570594 22 11.183594 22 L 5 22 C 4.448 22 4 21.551 4 21 L 4 9 C 4 8.449 4.448 8 5 8 z M 6 12 L 6 14 L 14 14 L 14 12 L 6 12 z M 18 12 L 18 14 L 26 14 L 26 12 L 18 12 z M 6 16 L 6 18 L 14 18 L 14 16 L 6 16 z M 18 16 L 18 18 L 26 18 L 26 16 L 18 16 z'/%3E%3C/svg%3E%0A");
+    margin-right: 0.5rem;
+  }
+`;
+
+const ProjectPortfolio: React.FC = () => {
+  return (
+    <ProjectPortfolioContainer>
+      <ProjectType>개인 프로젝트</ProjectType>
+      <Title>준승 포트폴리오</Title>
+      <ProjectPeriod>2022년 8월 22일 ~ 계속 개발 중</ProjectPeriod>
+      <ProjectExplain>hi</ProjectExplain>
+      <ProjectExplain>hi</ProjectExplain>
+      <ProjectExplain>hi</ProjectExplain>
+      <ProjectExplain>hi</ProjectExplain>
+      <ProjectExplain>hi</ProjectExplain>
+      <ProjectWorry>프로젝트 구현 시 했던 고민들</ProjectWorry>
+      <ProjectExplain><Link href="/">hi</Link></ProjectExplain>
+      <ProjectExplain>hi</ProjectExplain>
+      <ProjectExplain>hi</ProjectExplain>
+      <ProjectReadme>리드미</ProjectReadme>
+      <ProjectExplain>hi</ProjectExplain>
+    </ProjectPortfolioContainer>
+);
+};
+
+export default ProjectPortfolio;

--- a/components/resume/ProjectPortfolio.tsx
+++ b/components/resume/ProjectPortfolio.tsx
@@ -30,6 +30,8 @@ const ProjectPeriod = styled.div`
 `;
 
 const ProjectExplain = styled.div`
+  display: flex;
+  flex-wrap: wrap;
   font-size: 1.5rem;
 
   &::before {
@@ -38,7 +40,7 @@ const ProjectExplain = styled.div`
     
   }
 
-  line-height: 1rem;
+  line-height: 1.5rem;
 `;
 
 const ProjectWorry = styled.h4`
@@ -69,7 +71,11 @@ const ProjectPortfolio: React.FC = () => {
       <Title>준승 포트폴리오</Title>
       <ProjectPeriod>2022년 8월 22일 ~ 계속 개발 중</ProjectPeriod>
       <ProjectExplain>hi</ProjectExplain>
-      <ProjectExplain>hi</ProjectExplain>
+      <ProjectExplain>
+        haslkdjflkasjdfljasldjflksajdfljasldjflasj
+        dfljasldfjlaskjdfasdfasdjkhfkjashdkfhaskjd
+        hfkjashkdjfhaskhfkjashkjl
+      </ProjectExplain>
       <ProjectExplain>hi</ProjectExplain>
       <ProjectExplain>hi</ProjectExplain>
       <ProjectExplain>hi</ProjectExplain>

--- a/components/resume/ResumeHeader.tsx
+++ b/components/resume/ResumeHeader.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import styled from 'styled-components';
+import oc from 'open-color';
+
+type ResumHeaderType = { name: 'Education' | 'Project' | 'Share' };
+
+const ResumeTitle = styled.h2`
+  font-size: 5rem;
+
+  &::after {
+    content: '.';
+    color: ${oc.teal[6]}
+  }
+`;
+
+const ResumeLine = styled.div`
+  width: 100%;
+  height: 0.5rem;
+
+  margin-top: 2rem;
+  background-image: linear-gradient(90deg, ${oc.teal[6]} 20%, ${oc.cyan[6]} 80%);
+  margin-bottom: 5rem;
+`;
+
+const ResumeHeader: React.FC<ResumHeaderType> = ({ name }) => {
+  return (
+    <>
+      <ResumeTitle>{name}</ResumeTitle>
+      <ResumeLine />
+    </>
+);
+};
+
+export default ResumeHeader;

--- a/components/resume/ResumeTemplate.tsx
+++ b/components/resume/ResumeTemplate.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { ReactProps } from '@/types/common.types';
+
+const ResumeTemplateContainer = styled.div`
+  width: 100%;
+
+  display: flex;
+  flex-direction: column;
+
+  margin-top: 5rem;
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  height: auto;
+`;
+
+const ResumeTemplate: React.FC<ReactProps> = ({ children }) => {
+  return (
+    <ResumeTemplateContainer>
+      <Wrapper>
+        {children}
+      </Wrapper>
+    </ResumeTemplateContainer>
+  );
+};
+
+export default ResumeTemplate;

--- a/components/resume/ResumeTemplate.tsx
+++ b/components/resume/ResumeTemplate.tsx
@@ -8,22 +8,15 @@ const ResumeTemplateContainer = styled.div`
 
   display: flex;
   flex-direction: column;
+  align-items: center;
 
   margin-top: 5rem;
-`;
-
-const Wrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  height: auto;
 `;
 
 const ResumeTemplate: React.FC<ReactProps> = ({ children }) => {
   return (
     <ResumeTemplateContainer>
-      <Wrapper>
-        {children}
-      </Wrapper>
+      {children}
     </ResumeTemplateContainer>
   );
 };

--- a/components/resume/Share.tsx
+++ b/components/resume/Share.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import styled from 'styled-components';
+import oc from 'open-color';
+import { media, sizes } from '@/stylesheets/utils';
+
+const ShareContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  padding-left: 2rem;
+  padding-right: 2rem;
+
+  width: ${sizes.wide};
+
+  @media ${media.wide} {
+    width: 100%;
+  }
+
+  div + div {
+    margin-top: 1.2rem;
+  }
+
+  h3 + div {
+    margin-top: 1.2rem;
+  }
+
+  margin-top: 5rem;
+`;
+
+const ShareTitle = styled.h2`
+  font-size: 5rem;
+
+  &::after {
+    content: '.';
+    color: ${oc.teal[6]}
+  }
+`;
+
+const ShareLine = styled.div`
+  width: 100%;
+  height: 0.5rem;
+
+  margin-top: 2rem;
+  background-image: linear-gradient(90deg, ${oc.teal[6]} 20%, ${oc.cyan[6]} 80%);
+  margin-bottom: 1.5rem;
+`;
+
+const Title = styled.h3`
+  margin-top: 1.5rem;
+  font-size: 2.5rem;
+  font-weight: bold;
+`;
+
+const ShareExplain = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 1.5rem;
+
+  &::before {
+    content: url("data:image/svg+xml,%3Csvg width='18px' height='18px' viewBox='0 0 48 48' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='48' height='48' fill='white' fill-opacity='0.01'/%3E%3Cpath d='M43 11L16.875 37L5 25.1818' stroke='teal' stroke-width='4' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E%0A");    
+    margin-right: 0.5rem;
+    
+  }
+
+  line-height: 1.5rem;
+`;
+
+const ShareType = styled.div`
+  font-size: 1.5rem;
+`;
+
+const Share: React.FC = () => {
+  return (
+    <ShareContainer>
+      <ShareTitle>Share</ShareTitle>
+      <ShareLine />
+
+      <ShareType>블로그</ShareType>
+      <Title>벨로그</Title>
+      <ShareExplain>asdjfkld</ShareExplain>
+      <ShareExplain>asdjfkld</ShareExplain>
+
+    </ShareContainer>
+  );
+};
+
+export default Share;

--- a/components/resume/Share.tsx
+++ b/components/resume/Share.tsx
@@ -1,85 +1,60 @@
 import React from 'react';
 import styled from 'styled-components';
-import oc from 'open-color';
-import { media, sizes } from '@/stylesheets/utils';
+
+import { useRecoilValue } from 'recoil';
+import { shareState } from '@/atom/atom.resume';
+import { SharedType } from '@/types/atom.types';
+
+import * as ResumeStyle from '@/stylesheets/resume';
+
+import ResumeHeader from '@/components/resume/ResumeHeader';
 
 const ShareContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-
-  padding-left: 2rem;
-  padding-right: 2rem;
-
-  width: ${sizes.wide};
-
-  @media ${media.wide} {
-    width: 100%;
-  }
-
-  div + div {
-    margin-top: 1.2rem;
-  }
-
-  h3 + div {
-    margin-top: 1.2rem;
-  }
-
   margin-top: 5rem;
+  ${ResumeStyle.Container}
 `;
 
-const ShareTitle = styled.h2`
-  font-size: 5rem;
-
-  &::after {
-    content: '.';
-    color: ${oc.teal[6]}
-  }
-`;
-
-const ShareLine = styled.div`
-  width: 100%;
-  height: 0.5rem;
-
-  margin-top: 2rem;
-  background-image: linear-gradient(90deg, ${oc.teal[6]} 20%, ${oc.cyan[6]} 80%);
-  margin-bottom: 1.5rem;
-`;
-
-const Title = styled.h3`
-  margin-top: 1.5rem;
-  font-size: 2.5rem;
-  font-weight: bold;
-`;
-
-const ShareExplain = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  font-size: 1.5rem;
-
-  &::before {
-    content: url("data:image/svg+xml,%3Csvg width='18px' height='18px' viewBox='0 0 48 48' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='48' height='48' fill='white' fill-opacity='0.01'/%3E%3Cpath d='M43 11L16.875 37L5 25.1818' stroke='teal' stroke-width='4' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E%0A");    
-    margin-right: 0.5rem;
-    
-  }
-
-  line-height: 1.5rem;
+const ShareTitle = styled.h3`
+  ${ResumeStyle.Title}
 `;
 
 const ShareType = styled.div`
-  font-size: 1.5rem;
+  ${ResumeStyle.Type}
+`;
+
+const ShareExplain = styled.div`
+  ${ResumeStyle.Explain}
+`;
+
+const ShareContent = styled.ul`
+  li + li {
+    margin-top: 4rem;
+  }
 `;
 
 const Share: React.FC = () => {
+  const shares = useRecoilValue<SharedType []>(shareState);
+
   return (
     <ShareContainer>
-      <ShareTitle>Share</ShareTitle>
-      <ShareLine />
-
-      <ShareType>블로그</ShareType>
-      <Title>벨로그</Title>
-      <ShareExplain>asdjfkld</ShareExplain>
-      <ShareExplain>asdjfkld</ShareExplain>
-
+      <ResumeHeader name="Share" />
+      <ShareContent>
+        {
+          shares.map((share) => {
+            return (
+              <li key={share.id}>
+                <ShareType>{share.type}</ShareType>
+                <ShareTitle>{share.title}</ShareTitle>
+                {
+                  share.explains.map((explain) => {
+                    return <ShareExplain key={explain}>{explain}</ShareExplain>;
+                  })
+                }
+              </li>
+            );
+          })
+        }
+      </ShareContent>
     </ShareContainer>
   );
 };

--- a/lib/stylesheets/resume.ts
+++ b/lib/stylesheets/resume.ts
@@ -1,35 +1,39 @@
-import React from 'react';
-import styled from 'styled-components';
-import Link from 'next/link';
+import { css } from 'styled-components';
+import { media, sizes } from '@/stylesheets/utils';
 
-const ProjectPortfolioContainer = styled.div`
-  margin-top: 3rem;
+export const Container = css`
+  display: flex;
+  flex-direction: column;
+
+  padding-left: 2rem;
+  padding-right: 2rem;
+
+  width: ${sizes.wide};
+
+  @media ${media.wide} {
+    width: 100%;
+  }
 
   div + div {
     margin-top: 1.2rem;
   }
 
-  h4 + div {
+  h3 + div {
     margin-top: 1.2rem;
   }
 `;
 
-const ProjectType = styled.div`
-  font-size: 1.5rem;
-`;
-
-const Title = styled.h3`
+export const Title = css`
   margin-top: 1.5rem;
   font-size: 2.5rem;
   font-weight: bold;
 `;
 
-const ProjectPeriod = styled.div`
-  margin-top: 1.2rem;
-  font-size: 1rem;
+export const Type = css`
+  font-size: 1.5rem;
 `;
 
-const ProjectExplain = styled.div`
+export const Explain = css`
   display: flex;
   flex-wrap: wrap;
   font-size: 1.5rem;
@@ -43,7 +47,7 @@ const ProjectExplain = styled.div`
   line-height: 1.5rem;
 `;
 
-const ProjectWorry = styled.h4`
+export const WorryTitle = css`
   margin-top: 1.5rem;
   font-size: 1.5rem;
 
@@ -51,10 +55,9 @@ const ProjectWorry = styled.h4`
     content: url("data:image/svg+xml,%3Csvg width='20px' height='20px' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' x='0px' y='0px' viewBox='0 0 53 53' style='enable-background:new 0 0 53 53;' xml:space='preserve'%3E%3Cpath style='fill:%23EFCE4A;' d='M26.5,9c-8.837,0-16,7.164-16,16c0,7.089,4.615,13.091,11,15.192V50h2v3h6v-3h2v-9.808 c6.385-2.101,11-8.103,11-15.192C42.5,16.164,35.337,9,26.5,9z'/%3E%3Cg%3E%3Cpath style='fill:%23EFCE4A;' d='M26.5,0c-0.553,0-1,0.447-1,1v4c0,0.553,0.447,1,1,1s1-0.447,1-1V1C27.5,0.447,27.053,0,26.5,0z'/%3E%3Cpath style='fill:%23EFCE4A;' d='M50.5,24h-4c-0.553,0-1,0.447-1,1s0.447,1,1,1h4c0.553,0,1-0.447,1-1S51.053,24,50.5,24z'/%3E%3Cpath style='fill:%23EFCE4A;' d='M6.5,24h-4c-0.553,0-1,0.447-1,1s0.447,1,1,1h4c0.553,0,1-0.447,1-1S7.053,24,6.5,24z'/%3E%3Cpath style='fill:%23EFCE4A;' d='M42.764,7.322l-2.828,2.828c-0.391,0.391-0.391,1.023,0,1.414c0.195,0.195,0.451,0.293,0.707,0.293 s0.512-0.098,0.707-0.293l2.828-2.828c0.391-0.391,0.391-1.023,0-1.414S43.154,6.932,42.764,7.322z'/%3E%3Cpath style='fill:%23EFCE4A;' d='M11.65,38.436l-2.828,2.828c-0.391,0.391-0.391,1.023,0,1.414c0.195,0.195,0.451,0.293,0.707,0.293 s0.512-0.098,0.707-0.293l2.828-2.828c0.391-0.391,0.391-1.023,0-1.414S12.041,38.045,11.65,38.436z'/%3E%3Cpath style='fill:%23EFCE4A;' d='M41.35,38.436c-0.391-0.391-1.023-0.391-1.414,0s-0.391,1.023,0,1.414l2.828,2.828 c0.195,0.195,0.451,0.293,0.707,0.293s0.512-0.098,0.707-0.293c0.391-0.391,0.391-1.023,0-1.414L41.35,38.436z'/%3E%3Cpath style='fill:%23EFCE4A;' d='M10.236,7.322c-0.391-0.391-1.023-0.391-1.414,0s-0.391,1.023,0,1.414l2.828,2.828 c0.195,0.195,0.451,0.293,0.707,0.293s0.512-0.098,0.707-0.293c0.391-0.391,0.391-1.023,0-1.414L10.236,7.322z'/%3E%3C/g%3E%3Cpath style='fill:%23F7E6A1;' d='M15.5,26c-0.553,0-1-0.447-1-1c0-6.617,5.383-12,12-12c0.553,0,1,0.447,1,1s-0.447,1-1,1 c-5.514,0-10,4.486-10,10C16.5,25.553,16.053,26,15.5,26z'/%3E%3Cpolygon style='fill:%23556080;' points='21.5,43 21.5,50 23.5,50 23.5,53 29.5,53 29.5,50 31.5,50 31.5,43 '/%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3Cg%3E%3C/g%3E%3C/svg%3E%0A");
     margin-right: 0.5rem;
   }
-
 `;
 
-const ProjectReadme = styled.div`
+export const ReadmeTitle = css`
   margin-top: 1.2rem;
   font-size: 1.5rem;
 
@@ -63,30 +66,3 @@ const ProjectReadme = styled.div`
     margin-right: 0.5rem;
   }
 `;
-
-const ProjectPortfolio: React.FC = () => {
-  return (
-    <ProjectPortfolioContainer>
-      <ProjectType>개인 프로젝트</ProjectType>
-      <Title>준승 포트폴리오</Title>
-      <ProjectPeriod>2022년 8월 22일 ~ 계속 개발 중</ProjectPeriod>
-      <ProjectExplain>hi</ProjectExplain>
-      <ProjectExplain>
-        haslkdjflkasjdfljasldjflksajdfljasldjflasj
-        dfljasldfjlaskjdfasdfasdjkhfkjashdkfhaskjd
-        hfkjashkdjfhaskhfkjashkjl
-      </ProjectExplain>
-      <ProjectExplain>hi</ProjectExplain>
-      <ProjectExplain>hi</ProjectExplain>
-      <ProjectExplain>hi</ProjectExplain>
-      <ProjectWorry>프로젝트 구현 시 했던 고민들</ProjectWorry>
-      <ProjectExplain><Link href="/">hi</Link></ProjectExplain>
-      <ProjectExplain>hi</ProjectExplain>
-      <ProjectExplain>hi</ProjectExplain>
-      <ProjectReadme>리드미</ProjectReadme>
-      <ProjectExplain>hi</ProjectExplain>
-    </ProjectPortfolioContainer>
-);
-};
-
-export default ProjectPortfolio;

--- a/pages/resume.tsx
+++ b/pages/resume.tsx
@@ -1,0 +1,30 @@
+import { NextPage } from 'next';
+import { Helmet, HelmetProvider } from 'react-helmet-async';
+
+import ResumeTemplate from '@/components/resume/ResumeTemplate';
+import Project from '@/components/resume/Project';
+import ProjectPortfolio from '@/components/resume/ProjectPortfolio';
+
+const Resume: NextPage = () => {
+  return (
+    <>
+      <HelmetProvider>
+        <Helmet>
+          <meta lang="ko" />
+          <meta charSet="utf-8" />
+          <meta name="description" content="이 문서는 준승의 이력서 페이지입니다." />
+          <meta name="author" content="황준승" />
+          <title>준승&apos;s potofolio</title>
+          <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Rajdhani:700" />
+        </Helmet>
+      </HelmetProvider>
+      <ResumeTemplate>
+        <Project>
+          <ProjectPortfolio />
+        </Project>
+      </ResumeTemplate>
+    </>
+  );
+};
+
+export default Resume;

--- a/pages/resume.tsx
+++ b/pages/resume.tsx
@@ -4,6 +4,7 @@ import { Helmet, HelmetProvider } from 'react-helmet-async';
 import ResumeTemplate from '@/components/resume/ResumeTemplate';
 import Project from '@/components/resume/Project';
 import ProjectPortfolio from '@/components/resume/ProjectPortfolio';
+import Education from '@/components/resume/Eduction';
 
 const Resume: NextPage = () => {
   return (
@@ -19,6 +20,7 @@ const Resume: NextPage = () => {
         </Helmet>
       </HelmetProvider>
       <ResumeTemplate>
+        <Education />
         <Project>
           <ProjectPortfolio />
         </Project>

--- a/pages/resume.tsx
+++ b/pages/resume.tsx
@@ -3,7 +3,6 @@ import { Helmet, HelmetProvider } from 'react-helmet-async';
 
 import ResumeTemplate from '@/components/resume/ResumeTemplate';
 import Project from '@/components/resume/Project';
-import ProjectPortfolio from '@/components/resume/ProjectPortfolio';
 import Education from '@/components/resume/Eduction';
 import Share from '@/components/resume/Share';
 
@@ -22,9 +21,7 @@ const Resume: NextPage = () => {
       </HelmetProvider>
       <ResumeTemplate>
         <Education />
-        <Project>
-          <ProjectPortfolio />
-        </Project>
+        <Project />
         <Share />
       </ResumeTemplate>
     </>

--- a/pages/resume.tsx
+++ b/pages/resume.tsx
@@ -5,6 +5,7 @@ import ResumeTemplate from '@/components/resume/ResumeTemplate';
 import Project from '@/components/resume/Project';
 import ProjectPortfolio from '@/components/resume/ProjectPortfolio';
 import Education from '@/components/resume/Eduction';
+import Share from '@/components/resume/Share';
 
 const Resume: NextPage = () => {
   return (
@@ -24,6 +25,7 @@ const Resume: NextPage = () => {
         <Project>
           <ProjectPortfolio />
         </Project>
+        <Share />
       </ResumeTemplate>
     </>
   );

--- a/types/atom.types.ts
+++ b/types/atom.types.ts
@@ -1,0 +1,23 @@
+export type EduType = {
+  id: string;
+  type: '대학교' | '교육';
+  title: string;
+  explains: string[];
+};
+
+export type SharedType = {
+  id: string;
+  type: '블로그';
+  title: string;
+  explains: string[];
+};
+
+export type PjType = {
+  id: string;
+  type: '개인 프로젝트' | '팀 프로젝트';
+  title: string;
+  period: string;
+  explains: string[];
+  worries: string[];
+  readme: string;
+};


### PR DESCRIPTION
## What is the PR?

- Resolve : #30
- 참고 : 
[svg -> data url 변환](https://yoksel.github.io/url-encoder/)
[가상 요소 선택자에 svg 파일 넣기](https://mber.tistory.com/35)

## Changes
- 구현한 이미지
![스크린샷 2022-09-12 02 11 22](https://user-images.githubusercontent.com/78203399/189540308-0eb6a472-bcd8-45dd-9941-0caa78c8850d.png)


## Etc
<!-- 트러블 슈팅, 고민 등 서술 -->
1. 반복되는 컴포넌트(`Project`, `Education`, `Share`)가 많아서 어떻게 하면 코드를 줄일까에 대한 고민을 많이함
-> 각 컴포넌트가 전체적인 구조는 비슷하지만 데이터 구조가 살짝 달라서 어떻게 하면 재사용성을 높이는 코드를 짤 수 있을지 고민을 많이함
-> 공통된 태그 별로 style 설정하고 구현 
