### PR TITLE
<#33>  스크롤 페이지에서 Header, Footer 겹침 현상 방지

### DIFF
--- a/components/common/Footer.tsx
+++ b/components/common/Footer.tsx
@@ -11,18 +11,18 @@ import LinkButton from './Link';
 
 const FooterContainer = styled.footer`
   width: 100%;
-  position: fixed;
-  bottom: 0px;
+  position: absolute;
+  bottom: 0;
 
   background-color: ${oc.gray[4]};
   display: flex;
   justify-content: center;
-  height: auto;
+  height: 2.5rem;
 `;
 
 const FooterContents = styled.div`
   width: ${sizes.wide};
-  height: 55px;
+
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/components/common/Header.tsx
+++ b/components/common/Header.tsx
@@ -12,6 +12,7 @@ import DarkModeButton from '@/components/home/DarkModeButton';
 
 const HeaderContainer = styled.div`
   position: sticky;
+  backdrop-filter: blur(10px);
   top: 0px;
   
   width: 100%;
@@ -19,6 +20,7 @@ const HeaderContainer = styled.div`
   
   display: flex;
   justify-content: center;
+  z-index: 10;
   
   ${shadow(1)}
 `;

--- a/components/common/Layout.tsx
+++ b/components/common/Layout.tsx
@@ -7,15 +7,21 @@ import Footer from '@/components/common/Footer';
 import { ReactProps } from '@/types/common.types';
 
 const StyledLayout = styled.div`
-  width: 100%;
-  display: flex;
-  flex-direction: column;
+  position: relative;
+  min-height: 100vh;
 `;
 
-const Layout: React.FC<ReactProps> = () => {
+const ContentWrapper = styled.div`
+  padding-bottom: 2.5rem;
+`;
+
+const Layout: React.FC<ReactProps> = ({ children }) => {
   return (
     <StyledLayout>
-      <Header />
+      <ContentWrapper>
+        <Header />
+        {children}
+      </ContentWrapper>
       <Footer />
     </StyledLayout>
   );

--- a/components/resume/ResumeTemplate.tsx
+++ b/components/resume/ResumeTemplate.tsx
@@ -10,7 +10,8 @@ const ResumeTemplateContainer = styled.div`
   flex-direction: column;
   align-items: center;
 
-  margin-top: 5rem;
+  padding-top: 5rem;
+  padding-bottom: 5rem;
 `;
 
 const ResumeTemplate: React.FC<ReactProps> = ({ children }) => {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -12,7 +12,7 @@ import {
 } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import Provider from '@/components/common/Provider';
-import Layout from '@/components/common/Layout';
+// import Layout from '@/components/common/Layout';
 
 function MyApp({ Component, pageProps }: AppProps) {
   const [queryClient] = React.useState(() => new QueryClient({
@@ -28,7 +28,6 @@ function MyApp({ Component, pageProps }: AppProps) {
       <Provider>
         <QueryClientProvider client={queryClient}>
           <Hydrate state={pageProps.dehydratedState}>
-            <Layout />
             <Component {...pageProps} />
             <ReactQueryDevtools initialIsOpen />
           </Hydrate>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,6 +2,7 @@ import type { NextPage } from 'next';
 import { Helmet, HelmetProvider } from 'react-helmet-async';
 
 import Introduce from '@/components/home/Introduce';
+import Layout from '@/components/common/Layout';
 
 const Home: NextPage = () => {
   return (
@@ -16,7 +17,9 @@ const Home: NextPage = () => {
           <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Rajdhani:700" />
         </Helmet>
       </HelmetProvider>
-      <Introduce />
+      <Layout>
+        <Introduce />
+      </Layout>
     </>
   );
 };

--- a/pages/project.tsx
+++ b/pages/project.tsx
@@ -8,18 +8,17 @@ import { ProjectAPI, ProjectResult } from '@/types/project.types';
 import { getNotionApi } from '@/api/getNotionApi';
 
 import ProjectList from '@/components/project/ProjectList';
+import Layout from '@/components/common/Layout';
 
 const Project: NextPage = () => {
   const [showChild, setShowChild] = useState(false);
   const project = useQuery<ProjectAPI<ProjectResult>>(['project'], async () => getNotionApi());
 
-  // 클라이언트 측 하이드레이션이 표시될 때까지 대기
   useEffect(() => {
     setShowChild(true);
   }, []);
 
   if (!showChild) {
-    // 처음 자리표시자 UI를 표시할 수 있다.
     return null;
   }
 
@@ -35,7 +34,9 @@ const Project: NextPage = () => {
           <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Rajdhani:700" />
         </Helmet>
       </HelmetProvider>
-      <ProjectList pj={project} />
+      <Layout>
+        <ProjectList pj={project} />
+      </Layout>
     </>
   );
 };

--- a/pages/resume.tsx
+++ b/pages/resume.tsx
@@ -5,6 +5,7 @@ import ResumeTemplate from '@/components/resume/ResumeTemplate';
 import Project from '@/components/resume/Project';
 import Education from '@/components/resume/Eduction';
 import Share from '@/components/resume/Share';
+import Layout from '@/components/common/Layout';
 
 const Resume: NextPage = () => {
   return (
@@ -19,11 +20,13 @@ const Resume: NextPage = () => {
           <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Rajdhani:700" />
         </Helmet>
       </HelmetProvider>
-      <ResumeTemplate>
-        <Education />
-        <Project />
-        <Share />
-      </ResumeTemplate>
+      <Layout>
+        <ResumeTemplate>
+          <Education />
+          <Project />
+          <Share />
+        </ResumeTemplate>
+      </Layout>
     </>
   );
 };


### PR DESCRIPTION
## What is the PR?

- Resolve : #33
- 참고 : 
[sticky-header](https://www.daleseo.com/css-position-sticky-header/)
[footer 겹침현상 해결하기](https://www.freecodecamp.org/news/how-to-keep-your-footer-where-it-belongs-59c6aa05c59c/)

## Changes
<!-- 변경된 사항 -->
footer: 스크롤 시 페이지 footer에 가려져서 페이지 내용이 가려지는 버그 수정
- position: fixed -> absolute (자세한 내용은 위의 링크에)

header: 스크롤 시 header와 페이지 컨텐츠 글씨 내용이 겹쳐서 사용자 UX 경험을 해칠 수 있다고 판단
- backdrop-filter 속성을 이용하여 header와 컨텐츠 내용 명확히 구분
