### PR TITLE
<#40> 새로고침 시 다크모드 상태 유지

### DIFF
--- a/components/home/DarkModeButton.tsx
+++ b/components/home/DarkModeButton.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import { useRecoilValue } from 'recoil';
 
 import oc from 'open-color';
 import styled from 'styled-components';
 import { ReactProps } from '@/types/common.types';
-import { themeState } from '@/atom/atom.theme';
 
 import Button from '@/components/common/Button';
 
@@ -16,10 +14,11 @@ const DarkModeStyledButton = styled(Button)`
 `;
 
 const DarkModeButton: React.FC<ReactProps> = () => {
-  const theme = useRecoilValue(themeState);
-  const [, toggleTheme] = useDarkMode();
+  const [theme, mounted, toggleTheme] = useDarkMode();
 
   const clikcDarkModeBtn = () => toggleTheme();
+
+  if (!mounted) return <div>Not Mounted!</div>;
 
   return (
     <DarkModeStyledButton variant="solid" colorScheme={oc.gray[5]} onClick={clikcDarkModeBtn}>

--- a/components/resume/ResumeTemplate.tsx
+++ b/components/resume/ResumeTemplate.tsx
@@ -18,22 +18,26 @@ const ResumeTemplateContainer = styled.div`
 `;
 
 const ResumeTemplate: React.FC = () => {
-  const { current } = useRef(['edu', 'pj', 'share']);
+  const { current } = useRef([
+    { id: 1, text: 'edu' },
+    { id: 2, text: 'pj' },
+    { id: 3, text: 'shar' },
+  ]);
 
   return (
     <ResumeTemplateContainer>
       {
         current.map((template) => {
           return (
-            <FadeInSection>
+            <FadeInSection key={template.id}>
               {
-                template === 'edu' && <Education />
+                template.text === 'edu' && <Education />
               }
               {
-                template === 'pj' && <Project />
+                template.text === 'pj' && <Project />
               }
               {
-                template === 'share' && <Share />
+                template.text === 'share' && <Share />
               }
             </FadeInSection>
           );

--- a/components/resume/ResumeTemplate.tsx
+++ b/components/resume/ResumeTemplate.tsx
@@ -21,7 +21,7 @@ const ResumeTemplate: React.FC = () => {
   const { current } = useRef([
     { id: 1, text: 'edu' },
     { id: 2, text: 'pj' },
-    { id: 3, text: 'shar' },
+    { id: 3, text: 'share' },
   ]);
 
   return (

--- a/lib/hooks/useDarkMode.ts
+++ b/lib/hooks/useDarkMode.ts
@@ -1,17 +1,33 @@
 import { useRecoilState } from 'recoil';
-
+import { useEffect, useState } from 'react';
 import { themeState } from '@/atom/atom.theme';
 
-export const useDarkMode = (): [string, () => void] => {
+export const useDarkMode = (): [string, boolean, () => void] => {
   const [theme, setTheme] = useRecoilState(themeState);
+  const [mounted, setMounted] = useState(false);
+
+  const setMode = (mode: string) => {
+    window.localStorage.setItem('hwjs', mode);
+    setTheme(mode);
+  };
 
   const toggleTheme = () => {
     if (theme === 'light') {
-      setTheme('dark');
+      setMode('dark');
     } else {
-      setTheme('light');
+      setMode('light');
     }
   };
 
-  return [theme, toggleTheme];
+  useEffect(() => {
+    const localTheme = window.localStorage.getItem('hwjs');
+
+    if (localTheme !== null) {
+      setTheme(localTheme);
+    }
+
+    setMounted(true);
+  }, [setTheme, theme]);
+
+  return [theme, mounted, toggleTheme];
 };

--- a/pages/project.tsx
+++ b/pages/project.tsx
@@ -3,7 +3,6 @@ import type { NextPage, GetStaticProps } from 'next';
 import { Helmet, HelmetProvider } from 'react-helmet-async';
 
 import { dehydrate, QueryClient, useQuery } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
 import { ProjectAPI, ProjectResult } from '@/types/project.types';
 import { getNotionApi } from '@/api/getNotionApi';
 
@@ -11,16 +10,9 @@ import ProjectList from '@/components/project/ProjectList';
 import Layout from '@/components/common/Layout';
 
 const Project: NextPage = () => {
-  const [showChild, setShowChild] = useState(false);
   const project = useQuery<ProjectAPI<ProjectResult>>(['project'], async () => getNotionApi());
 
-  useEffect(() => {
-    setShowChild(true);
-  }, []);
-
-  if (!showChild) {
-    return null;
-  }
+  if (project.isLoading) return <div>로딩중입니다...</div>;
 
   return (
     <>


### PR DESCRIPTION
## What is the PR?

- Resolve : #40 
- 참고 : 
[nextjs localStorage Code](https://codesandbox.io/s/nextjs-localstorage-forked-61ofnd?file=/pages/index.js:435-443)
[localStorage vs cookies](https://all-dev-kang.tistory.com/304)
[useLocalStorage](https://usehooks.com/useLocalStorage/)

## Changes
<!-- 변경된 사항 -->
- [x] 새로 고침 시 다크모드 상태 유지
- [x] 다크모드 상태에서 새로 고침 시 다크모드 화이트 -> 다크로 되는 문제 해결

## Etc
<!-- 트러블 슈팅, 고민 등 서술 -->
`localStorage`, `SessionStorage` 사용 시 SSR 구현이 불가능하다. -> window객체를 읽지 못하기 때문

하지만 `Cookie`를 사용 시 SSR 구현이 가능하다.

이 프로젝트의 경우 다크모드 버튼에 대한 정보만 SSR이 적용되지 않기 때문에 다크모드 동작의 경우 CSR로 구현하였는데 성능적인 면 UX적인 측면을 고려하여 정확히 어떤 점이 더 좋은지 고민을 더 해보아야겠다.
